### PR TITLE
feat!: Upgrade AWS provider and min required Terraform version to `6.0` and `1.5.7` respectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -74,6 +74,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_prometheus_alert_manager_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_alert_manager_definition) | resource |
 | [aws_prometheus_rule_group_namespace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_rule_group_namespace) | resource |
 | [aws_prometheus_workspace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_workspace) | resource |
@@ -83,12 +84,18 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alert_manager_definition"></a> [alert\_manager\_definition](#input\_alert\_manager\_definition) | The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html) | `string` | `"alertmanager_config: |\n  route:\n    receiver: 'default'\n  receivers:\n    - name: 'default'\n"` | no |
+| <a name="input_cloudwatch_log_group_class"></a> [cloudwatch\_log\_group\_class](#input\_cloudwatch\_log\_group\_class) | Specified the log class of the log group. Possible values are: `STANDARD` or `INFREQUENT_ACCESS` | `string` | `null` | no |
+| <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) | `string` | `null` | no |
+| <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | Custom name of CloudWatch log group for a service associated with the container definition | `string` | `null` | no |
+| <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | Number of days to retain log events. Set to `0` to keep logs indefinitely | `number` | `30` | no |
+| <a name="input_cloudwatch_log_group_use_name_prefix"></a> [cloudwatch\_log\_group\_use\_name\_prefix](#input\_cloudwatch\_log\_group\_use\_name\_prefix) | Determines whether the log group name should be used as a prefix | `bool` | `false` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |
 | <a name="input_create_alert_manager"></a> [create\_alert\_manager](#input\_create\_alert\_manager) | Controls whether an Alert Manager definition is created along with the AMP workspace | `bool` | `true` | no |
 | <a name="input_create_workspace"></a> [create\_workspace](#input\_create\_workspace) | Determines whether a workspace will be created or to use an existing workspace | `bool` | `true` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS Key to for encryption at rest | `string` | `null` | no |
-| <a name="input_logging_configuration"></a> [logging\_configuration](#input\_logging\_configuration) | The logging configuration of the prometheus workspace. | `map(string)` | `{}` | no |
-| <a name="input_rule_group_namespaces"></a> [rule\_group\_namespaces](#input\_rule\_group\_namespaces) | A map of one or more rule group namespace definitions | `map(any)` | `{}` | no |
+| <a name="input_logging_configuration"></a> [logging\_configuration](#input\_logging\_configuration) | The logging configuration of the prometheus workspace. | <pre>object({<br/>    create_log_group      = optional(bool, true)<br/>    logging_configuration = optional(string)<br/>  })</pre> | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region where the resource(s) will be managed. Defaults to the Region set in the provider configuration | `string` | `null` | no |
+| <a name="input_rule_group_namespaces"></a> [rule\_group\_namespaces](#input\_rule\_group\_namespaces) | A map of one or more rule group namespace definitions | <pre>map(object({<br/>    name = string<br/>    data = string<br/>  }))</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_workspace_alias"></a> [workspace\_alias](#input\_workspace\_alias) | The alias of the prometheus workspace. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-create-workspace.html) | `string` | `null` | no |
 | <a name="input_workspace_id"></a> [workspace\_id](#input\_workspace\_id) | The ID of an existing workspace to use when `create_workspace` is `false` | `string` | `""` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -11,9 +11,9 @@ Configuration in this directory creates:
 To run this example you need to execute:
 
 ```bash
-$ terraform init
-$ terraform plan
-$ terraform apply
+terraform init
+terraform plan
+terraform apply
 ```
 
 Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
@@ -23,14 +23,12 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+No providers.
 
 ## Modules
 
@@ -42,9 +40,7 @@ Note that this example may create resources which will incur monetary charges on
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+No resources.
 
 ## Inputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 locals {
   region = "us-east-1"
-  name   = "amp-ex-${replace(basename(path.cwd), "_", "-")}"
+  name   = "amp-ex-${basename(path.cwd)}"
 }
 
 ################################################################################
@@ -16,7 +16,9 @@ module "prometheus" {
 
   workspace_alias = local.name
   logging_configuration = {
-    log_group_arn = "${aws_cloudwatch_log_group.this.arn}:*"
+    create_log_group = true
+    # To use externally created log group
+    # log_group_arn = "${aws_cloudwatch_log_group.this.arn}:*"
   }
 
   create_alert_manager     = true
@@ -52,21 +54,14 @@ module "prometheus" {
   }
 }
 
-module "disabled" {
-  source = "../.."
-
-  create = false
-}
-
 module "default" {
   source = "../.."
 
   workspace_alias = "${local.name}-default"
 }
 
-################################################################################
-# Supporting Resources
-################################################################################
-resource "aws_cloudwatch_log_group" "this" {
-  name = "example-aws-managed-service-prometheus-complete"
+module "disabled" {
+  source = "../.."
+
+  create = false
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 6.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -9,16 +9,40 @@ locals {
 resource "aws_prometheus_workspace" "this" {
   count = var.create && var.create_workspace ? 1 : 0
 
+  region = var.region
+
   alias       = var.workspace_alias
   kms_key_arn = var.kms_key_arn
 
   dynamic "logging_configuration" {
-    for_each = length(var.logging_configuration) > 0 ? [var.logging_configuration] : []
+    for_each = var.logging_configuration != null ? [var.logging_configuration] : []
 
     content {
-      log_group_arn = logging_configuration.value.log_group_arn
+      log_group_arn = logging_configuration.value.create_log_group ? "${aws_cloudwatch_log_group.this[0].arn}:*" : logging_configuration.value.log_group_arn
     }
   }
+
+  tags = var.tags
+}
+
+################################################################################
+# Cloudwatch Log Group
+################################################################################
+
+locals {
+  log_group_name = try(coalesce(var.cloudwatch_log_group_name, "/aws/prometheus/${var.workspace_alias}"), "")
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  count = var.create && var.create_workspace && try(coalesce(var.logging_configuration.create_log_group), true) ? 1 : 0
+
+  region = var.region
+
+  name              = var.cloudwatch_log_group_use_name_prefix ? null : local.log_group_name
+  name_prefix       = var.cloudwatch_log_group_use_name_prefix ? "${local.log_group_name}-" : null
+  log_group_class   = var.cloudwatch_log_group_class
+  retention_in_days = var.cloudwatch_log_group_retention_in_days
+  kms_key_id        = var.cloudwatch_log_group_kms_key_id
 
   tags = var.tags
 }
@@ -30,6 +54,8 @@ resource "aws_prometheus_workspace" "this" {
 resource "aws_prometheus_alert_manager_definition" "this" {
   count = var.create && var.create_alert_manager ? 1 : 0
 
+  region = var.region
+
   workspace_id = local.workspace_id
   definition   = var.alert_manager_definition
 }
@@ -39,7 +65,9 @@ resource "aws_prometheus_alert_manager_definition" "this" {
 ################################################################################
 
 resource "aws_prometheus_rule_group_namespace" "this" {
-  for_each = var.create ? var.rule_group_namespaces : {}
+  for_each = var.create && var.rule_group_namespaces != null ? var.rule_group_namespaces : {}
+
+  region = var.region
 
   name         = each.value.name
   workspace_id = local.workspace_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,15 +4,15 @@
 
 output "workspace_arn" {
   description = "Amazon Resource Name (ARN) of the workspace"
-  value       = try(aws_prometheus_workspace.this[0].arn, "")
+  value       = try(aws_prometheus_workspace.this[0].arn, null)
 }
 
 output "workspace_id" {
   description = "Identifier of the workspace"
-  value       = try(aws_prometheus_workspace.this[0].id, "")
+  value       = try(aws_prometheus_workspace.this[0].id, null)
 }
 
 output "workspace_prometheus_endpoint" {
   description = "Prometheus endpoint available for this workspace"
-  value       = try(aws_prometheus_workspace.this[0].prometheus_endpoint, "")
+  value       = try(aws_prometheus_workspace.this[0].prometheus_endpoint, null)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "create" {
   default     = true
 }
 
+variable "region" {
+  description = "Region where the resource(s) will be managed. Defaults to the Region set in the provider configuration"
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources"
   type        = map(string)
@@ -34,12 +40,49 @@ variable "workspace_alias" {
 
 variable "logging_configuration" {
   description = "The logging configuration of the prometheus workspace."
-  type        = map(string)
-  default     = {}
+  type = object({
+    create_log_group      = optional(bool, true)
+    logging_configuration = optional(string)
+  })
+  default = null
 }
 
 variable "kms_key_arn" {
   description = "The ARN of the KMS Key to for encryption at rest"
+  type        = string
+  default     = null
+}
+
+################################################################################
+# CloudWatch Log Group
+################################################################################
+
+variable "cloudwatch_log_group_name" {
+  description = "Custom name of CloudWatch log group for a service associated with the container definition"
+  type        = string
+  default     = null
+}
+
+variable "cloudwatch_log_group_use_name_prefix" {
+  description = "Determines whether the log group name should be used as a prefix"
+  type        = bool
+  default     = false
+}
+
+variable "cloudwatch_log_group_class" {
+  description = "Specified the log class of the log group. Possible values are: `STANDARD` or `INFREQUENT_ACCESS`"
+  type        = string
+  default     = null
+}
+
+variable "cloudwatch_log_group_retention_in_days" {
+  description = "Number of days to retain log events. Set to `0` to keep logs indefinitely"
+  type        = number
+  default     = 30
+}
+
+variable "cloudwatch_log_group_kms_key_id" {
+  description = "If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)"
   type        = string
   default     = null
 }
@@ -72,6 +115,9 @@ variable "alert_manager_definition" {
 
 variable "rule_group_namespaces" {
   description = "A map of one or more rule group namespace definitions"
-  type        = map(any)
-  default     = {}
+  type = map(object({
+    name = string
+    data = string
+  }))
+  default = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 6.0"
     }
   }
 }


### PR DESCRIPTION
## Description

## List of backwards incompatible changes

- Terraform `v1.5.7` is now minimum supported version
- AWS provider `v6.0` is now minimum supported version

## Additional changes

### Added

- Support for `region` argument to specify the AWS region for the resources created if different from the provider region.
- Support for creating the CloudWatch log group within the module

### Modified

- Variable definitions now contain detailed object types in place of the previously used `any` type

## Motivation and Context
- Unblocks #23 

## Breaking Changes
- Yes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request