### PR TITLE
fix: Skip `limits_per_label_set` dynamic block when set to `null`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "aws_prometheus_workspace_configuration" "this" {
   workspace_id             = local.workspace_id
 
   dynamic "limits_per_label_set" {
-    for_each = coalesce(var.limits_per_label_set, [])
+    for_each = var.limits_per_label_set != null ? var.limits_per_label_set : []
 
     content {
       label_set = limits_per_label_set.value.label_set


### PR DESCRIPTION
## Description
Guards `limits_per_label_set` in `aws_prometheus_workspace_configuration` as `for_each` doesn't expect null

## Motivation and Context
Fixes https://github.com/terraform-aws-modules/terraform-aws-managed-service-prometheus/issues/27

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
