### PR TITLE
fix: Revert remove `limits_per_label_set` from `aws_prometheus_workspace_configuration` conditional creation statement (#31)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "aws_prometheus_workspace" "this" {
 ################################################################################
 
 resource "aws_prometheus_workspace_configuration" "this" {
-  count = var.create && var.create_workspace ? 1 : 0
+  count = var.create && var.create_workspace && var.limits_per_label_set != null ? 1 : 0
 
   region = var.region
 


### PR DESCRIPTION
## Description
- Revert remove `limits_per_label_set` from `aws_prometheus_workspace_configuration` conditional creation statement (#31)

## Motivation and Context
- Resolves #33

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
